### PR TITLE
chore: bump versie-nr naar 2.7.0

### DIFF
--- a/src/BrpProxy/BrpProxy.csproj
+++ b/src/BrpProxy/BrpProxy.csproj
@@ -7,7 +7,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
     <DockerComposeProjectPath>..\..\docker-compose.dcproj</DockerComposeProjectPath>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />


### PR DESCRIPTION
Past het versie-nr van de personen-mock aan naar 2.7.0